### PR TITLE
把DragonReach的名称改为小写.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dragon_reach"
+name = "dragonreach"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "DragonReach"
+name = "dragonreach"
 path = "src/main.rs"
 
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod contants;
 mod error;
 mod executor;


### PR DESCRIPTION
- 原因是rust要求crate名字是snakecase
- 便于用户使用的时候,命令行打字更方便一点.